### PR TITLE
allow array of strings for id_token aud(ience) attribute

### DIFF
--- a/lib/openid_connect/response_object/id_token.rb
+++ b/lib/openid_connect/response_object/id_token.rb
@@ -13,7 +13,7 @@ module OpenIDConnect
 
       def initialize(attributes = {})
         super
-        (all_attributes - [:exp, :iat, :auth_time, :sub_jwk]).each do |key|
+        (all_attributes - [:aud, :exp, :iat, :auth_time, :sub_jwk]).each do |key|
           self.send "#{key}=", self.send(key).try(:to_s)
         end
       end
@@ -21,7 +21,7 @@ module OpenIDConnect
       def verify!(expected = {})
         exp.to_i > Time.now.to_i &&
         iss == expected[:issuer] &&
-        aud == expected[:client_id] &&
+        Array(aud).include?(expected[:client_id]) && # aud(ience) can be a string or an array of strings
         nonce == expected[:nonce] or
         raise InvalidToken.new('Invalid ID Token')
       end

--- a/spec/openid_connect/response_object/id_token_spec.rb
+++ b/spec/openid_connect/response_object/id_token_spec.rb
@@ -31,6 +31,17 @@ describe OpenIDConnect::ResponseObject::IdToken do
         ).should be_true
       end
 
+      context 'when aud(ience) is an array of identifiers' do
+        let(:client_id) { 'client_id' }
+        let(:attributes) { required_attributes.merge(aud: ['some_other_identifier', client_id]) }
+        it do
+          id_token.verify!(
+            issuer: attributes[:iss],
+            client_id: client_id
+          ).should be_true
+        end
+      end
+
       context 'when expired' do
         let(:ext) { 10.minutes.ago }
         it do


### PR DESCRIPTION
The OpenID Connect spec says that the "aud" attribute of an ID Token can be either a single string or an array of strings:

  http://openid.net/specs/openid-connect-messages-1_0-20.html

> **aud** REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain identifiers for other audiences. In the general case, the aud value is an array of case sensitive strings. In the special case when there is one audience, the aud value MAY be a single case sensitive string.

I've actually run into an OpenID Connect server that returns an array (with a single element). This pull supports an array of identifiers, with the client_id present anywhere in the array.
