### PR TITLE
support JSON Web key 'kid' parameter

### DIFF
--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -88,6 +88,15 @@ module OpenIDConnect
               JSON::JWK.decode jwk
             end
           end
+
+          def public_keys_with_kid
+            @public_keys_with_kid ||= lambda {|hash|
+              jwks.each do |jwk|
+                hash.merge!({jwk[:kid] => JSON::JWK.decode(jwk)}) unless jwk[:kid].nil?
+              end
+              hash
+            }.call({})
+          end
         end
       end
     end

--- a/spec/mock_response/public_keys/jwks.json
+++ b/spec/mock_response/public_keys/jwks.json
@@ -2,6 +2,7 @@
   "keys": [{
     "kty": "RSA",
     "e": "AQAB",
-    "n": "u4liYNFzgsRr1ERdUY7CY6r4nefi3RzIhK5fdPgdZSMEEflACWAuJu21_TcDpbZ1-6Kbq7zShFsVTAnBkWdO7EP1Rsn11fZpi9m_zEq_uRY-4RpNwp3S9xSdoQ4F3-js1EMaDQ6km0-c0gvr_TyhFqDj_6w_Bb0vFptfGXwfKewPPnhsi7GJ62ihZ32PzxOvEIYcaoXr9xaeudYD3BzWSDmjKGA7PMaEuBhScdUAoibCmsKB-yAGsz2amHnUhcl4B_EBs6wk65Y7ge0ZQJUOGPdUQL49VuALKmr7cMhHKh5KuQmPAi_20K2uZL_EFDaObDWZrclx98s0DmfTRKINtw"
+    "n": "u4liYNFzgsRr1ERdUY7CY6r4nefi3RzIhK5fdPgdZSMEEflACWAuJu21_TcDpbZ1-6Kbq7zShFsVTAnBkWdO7EP1Rsn11fZpi9m_zEq_uRY-4RpNwp3S9xSdoQ4F3-js1EMaDQ6km0-c0gvr_TyhFqDj_6w_Bb0vFptfGXwfKewPPnhsi7GJ62ihZ32PzxOvEIYcaoXr9xaeudYD3BzWSDmjKGA7PMaEuBhScdUAoibCmsKB-yAGsz2amHnUhcl4B_EBs6wk65Y7ge0ZQJUOGPdUQL49VuALKmr7cMhHKh5KuQmPAi_20K2uZL_EFDaObDWZrclx98s0DmfTRKINtw",
+    "kid": "4d676cf356b3d119b812473ed5c68b3009a4657e"
   }]
 }

--- a/spec/openid_connect/discovery/provider/config/response_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/response_spec.rb
@@ -80,4 +80,16 @@ describe OpenIDConnect::Discovery::Provider::Config::Response do
       public_keys.first.should be_instance_of OpenSSL::PKey::RSA
     end
   end
+
+  describe '#public_keys_with_kid' do
+    it do
+      public_keys_with_kid = mock_json :get, jwks_uri, 'public_keys/jwks' do
+        instance.public_keys_with_kid
+      end
+      public_keys_with_kid.should be_instance_of Hash
+      public_keys_with_kid.keys.each do |key|
+        public_keys_with_kid[key].should be_instance_of OpenSSL::PKey::RSA
+      end
+    end
+  end
 end


### PR DESCRIPTION
http://tools.ietf.org/html/draft-ietf-jose-json-web-key-31#section-4.5

support the kid parameter. if parameters are included in the JWK set.
implemented different method, considering the impact on existing applications.
