### PR TITLE
Add support for providers using multiple public keys

### DIFF
--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -83,6 +83,12 @@ module OpenIDConnect
             JSON::JWK::Set.new @jwks[:keys]
           end
 
+          def public_keys_hash
+            @public_keys_hash ||= jwks.collect do |jwk|
+              {:kid => jwk[:kid], :key => JSON::JWK.decode(jwk)}
+            end
+          end
+
           def public_keys
             @public_keys ||= jwks.collect do |jwk|
               JSON::JWK.decode jwk

--- a/lib/openid_connect/response_object/id_token.rb
+++ b/lib/openid_connect/response_object/id_token.rb
@@ -53,6 +53,14 @@ module OpenIDConnect
       end
 
       class << self
+        def decode_with_keys(jwt_string, keys)
+          if keys.count == 1 and keys[0][:key] == :self_issued
+            decode_self_issued jwt_string
+          else
+            new JSON::JWT.decode_with_keys jwt_string, keys
+          end
+        end
+
         def decode(jwt_string, key)
           if key == :self_issued
             decode_self_issued jwt_string

--- a/spec/helpers/crypto_spec_helper.rb
+++ b/spec/helpers/crypto_spec_helper.rb
@@ -1,14 +1,26 @@
 module CryptoSpecHelper
-  def rsa_key
-    @rsa_key ||= OpenSSL::PKey::RSA.generate 2048
+  def rsa_key1
+    @rsa_key1 ||= OpenSSL::PKey::RSA.generate 2048
+  end
+
+  def rsa_key2
+    @rsa_key2 ||= OpenSSL::PKey::RSA.generate 2048
+  end
+
+  def public_keys_hash
+    @public_key ||= [{:kid => '1', :key => rsa_key1.public_key}, {:kid => '2', :key => rsa_key2.public_key}]
   end
 
   def public_key
-    @public_key ||= rsa_key.public_key
+    @public_key ||= rsa_key1.public_key
   end
 
   def private_key
-    @private_key ||= OpenSSL::PKey::RSA.new rsa_key.export(OpenSSL::Cipher::Cipher.new('DES-EDE3-CBC'), 'pass-phrase'), 'pass-phrase'
+    @private_key ||= OpenSSL::PKey::RSA.new rsa_key1.export(OpenSSL::Cipher::Cipher.new('DES-EDE3-CBC'), 'pass-phrase'), 'pass-phrase'
+  end
+
+  def private_key2
+    @private_key ||= OpenSSL::PKey::RSA.new rsa_key2.export(OpenSSL::Cipher::Cipher.new('DES-EDE3-CBC'), 'pass-phrase'), 'pass-phrase'
   end
 
   def ec_key

--- a/spec/mock_response/public_keys/jwks_kids.json
+++ b/spec/mock_response/public_keys/jwks_kids.json
@@ -1,0 +1,20 @@
+{
+ "keys": [
+  {
+   "kty": "RSA",
+   "alg": "RS256",
+   "use": "sig",
+   "kid": "a1a985a59256d026e252d5b5faddf9b6b41e32e3",
+   "n": "0TdvjCe7CCZo5H5g0yuc3PSl6HEY9FnSc_paPK1Os8-66KWBi_zLjXO_FBBdpvJKBOj1DRGsKI8oVBXPCBzzoC8GqTY2PW6FUEvhNbgBIR-yDE_SNTnxX6Vj5MQiS2jEEKOrYlkQNnuSpHacji4nRAG1_AiqFlaQhBZ8FpftCi0-mkehMPzHwE9wqK-1H0Xcb__wc76GsGxytN3hKBLZu4NertXcdlRaKEPeH_xgY7wgNYb7dZWJFOCsIogFSjFJ9fQ6vzZs5qLFGQBlQUzXMF_pDDsHWMYghAPW-ei7AvDQN0eBgYF1xoA-feoztoLqgJMkpGrT4qluBbFM-HXXaQ",
+   "e": "AQAB"
+  },
+  {
+   "kty": "RSA",
+   "alg": "RS256",
+   "use": "sig",
+   "kid": "c13a48bfea7287d05629fd6c7c673b23eefafe4f",
+   "n": "ojyBUzajk3-2d_eDgd-mQ1164lVEjOH7q5l54yJ5vHcFcloxz0bRFEsYxQ8B9nBm83Xv8SG0kKG_sn0C_UEnj-FpHTxgzjUn7yZWq8YWbS_DDjWDfKWNzGes5ZngvKJ9JN31_NgYRCih8mt5MeKqtTJzDJQ1sbwMUfIbFh5Z42nhhJBFP_DkrcvRrvo2-fuEBQAfJzXXgR8658gX9lmHiVdKqCWg1a7Wleqjxsnz_LPt11WbV0Oz8mShlM6MTKm0baxz3WGEDxPxxCnM46wJZk6-j3wEiXsgZquB_hwqcaP-NS6eIIBJtxXLMC7cmEyY_qVUB1Kxh4OGOsTnQ_Rx6Q",
+   "e": "AQAB"
+  }
+ ]
+}

--- a/spec/openid_connect/discovery/provider/config/response_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/response_spec.rb
@@ -71,6 +71,35 @@ describe OpenIDConnect::Discovery::Provider::Config::Response do
     end
   end
 
+  describe '#public_keys_hash' do
+    context 'when jwks without kids' do
+      it do
+        public_keys_with_kid = mock_json :get, jwks_uri, 'public_keys/jwks' do
+          instance.public_keys_hash
+        end
+        public_keys_with_kid.should be_instance_of Array
+        public_keys_with_kid[0].should be_instance_of Hash
+        public_keys_with_kid[0][:kid].should be_nil
+        public_keys_with_kid[0][:key].should be_instance_of OpenSSL::PKey::RSA
+      end
+    end
+
+    context 'when jwks with kids' do
+      it do
+        public_keys_with_kid = mock_json :get, jwks_uri, 'public_keys/jwks_kids' do
+          instance.public_keys_hash
+        end
+        public_keys_with_kid.should be_instance_of Array
+        public_keys_with_kid[0].should be_instance_of Hash
+        public_keys_with_kid[0][:kid].should eq("a1a985a59256d026e252d5b5faddf9b6b41e32e3")
+        public_keys_with_kid[0][:key].should be_instance_of OpenSSL::PKey::RSA
+        public_keys_with_kid[1].should be_instance_of Hash
+        public_keys_with_kid[1][:kid].should eq("c13a48bfea7287d05629fd6c7c673b23eefafe4f")
+        public_keys_with_kid[1][:key].should be_instance_of OpenSSL::PKey::RSA
+      end
+    end
+  end
+
   describe '#public_keys' do
     it do
       public_keys = mock_json :get, jwks_uri, 'public_keys/jwks' do


### PR DESCRIPTION
Fixes verification exception in omniauth-openid-connect that currently
assumes first public key is always used.

Add deocde_with_keys to Discovery::Config::Response
Keys are an array of pair hashes [{:kid => ..., :key => ...], ...]}.
Needed to be able to match kid when jwks contains multiple keys.

Add public_keys_hash to OpenIDConnect::ResponseObject::IdToken
Returns an array of pair hashes [{:kid => ..., :key => ...], ...]}.

Requires json-jwt gem with multiple keys support.

jwks_kids.json from https://www.googleapis.com/oauth2/v3/certs