### PR TITLE
Add better error messagesd for invalid ID tokens

### DIFF
--- a/lib/openid_connect/response_object/id_token.rb
+++ b/lib/openid_connect/response_object/id_token.rb
@@ -4,6 +4,10 @@ module OpenIDConnect
   class ResponseObject
     class IdToken < ConnectObject
       class InvalidToken < Exception; end
+      class ExpiredToken < InvalidToken; end
+      class InvalidIssuer < InvalidToken; end
+      class InvalidNonce < InvalidToken; end
+      class InvalidAudience < InvalidToken; end
 
       attr_required :iss, :sub, :aud, :exp, :iat
       attr_optional :acr, :auth_time, :nonce, :sub_jwk, :at_hash, :c_hash
@@ -20,13 +24,13 @@ module OpenIDConnect
       end
 
       def verify!(expected = {})
-        raise InvalidToken.new('Invalid ID token: Expired token') unless exp.to_i > Time.now.to_i
-        raise InvalidToken.new('Invalid ID token: Issuer does not match') unless iss == expected[:issuer]
-        raise InvalidToken.new('Invalid ID Token: Nonce does not match') unless nonce == expected[:nonce]
+        raise ExpiredToken.new('Invalid ID token: Expired token') unless exp.to_i > Time.now.to_i
+        raise InvalidIssuer.new('Invalid ID token: Issuer does not match') unless iss == expected[:issuer]
+        raise InvalidNonce.new('Invalid ID Token: Nonce does not match') unless nonce == expected[:nonce]
 
         # aud(ience) can be a string or an array of strings
         unless Array(aud).include?(expected[:audience] || expected[:client_id])
-          raise InvalidToken.new('Invalid ID token: Audience does not match')
+          raise InvalidAudience.new('Invalid ID token: Audience does not match')
         end
 
         true

--- a/lib/openid_connect/response_object/id_token.rb
+++ b/lib/openid_connect/response_object/id_token.rb
@@ -20,11 +20,16 @@ module OpenIDConnect
       end
 
       def verify!(expected = {})
-        exp.to_i > Time.now.to_i &&
-        iss == expected[:issuer] &&
-        Array(aud).include?(expected[:audience] || expected[:client_id]) && # aud(ience) can be a string or an array of strings
-        nonce == expected[:nonce] or
-        raise InvalidToken.new('Invalid ID Token')
+        raise InvalidToken.new('Invalid ID token: Expired token') unless exp.to_i > Time.now.to_i
+        raise InvalidToken.new('Invalid ID token: Issuer does not match') unless iss == expected[:issuer]
+        raise InvalidToken.new('Invalid ID Token: Nonce does not match') unless nonce == expected[:nonce]
+
+        # aud(ience) can be a string or an array of strings
+        unless Array(aud).include?(expected[:audience] || expected[:client_id])
+          raise InvalidToken.new('Invalid ID token: Audience does not match')
+        end
+
+        true
       end
 
       include JWTnizable


### PR DESCRIPTION
Rather than showing a generic "Invalid ID token" message when any part of an ID token is bad, show the specific field that didn't match the expected value. Much easier for developers to figure out what's going wrong.

This doesn't appear to require any modification to the test suite, as the *type* of error hasn't changed, and the test suite only tests the type of error raised, not the specific error message.