### PR TITLE
added check_session_iframe option to discovery response

### DIFF
--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -20,6 +20,7 @@ module OpenIDConnect
               :registration_endpoint,
               :end_session_endpoint,
               :service_documentation,
+              :check_session_iframe,
               :op_policy_uri,
               :op_tos_uri
             ]

--- a/spec/openid_connect/discovery/provider/config/response_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/response_spec.rb
@@ -46,6 +46,17 @@ describe OpenIDConnect::Discovery::Provider::Config::Response do
     its(:end_session_endpoint) { should == end_session_endpoint }
   end
 
+  context 'when check_session_iframe given' do
+    let(:check_session_iframe) { 'https://server.example.com/check_session_iframe.html' }
+    let :attributes do
+      minimum_attributes.merge(
+        check_session_iframe: check_session_iframe
+      )
+    end
+    it { should be_valid }
+    its(:check_session_iframe) { should == check_session_iframe }
+  end
+
   describe '#as_json' do
     subject { instance.as_json }
     it { should == minimum_attributes }


### PR DESCRIPTION
https://openid.net/specs/openid-connect-session-1_0.html#OPiframe

I had to get the uri from raw response before.