### PR TITLE
Remove unnecessary json gem dependency

### DIFF
--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_runtime_dependency "json", ">= 1.4.3"
   s.add_runtime_dependency "tzinfo"
   s.add_runtime_dependency "attr_required", ">= 1.0.0"
   s.add_runtime_dependency "activemodel"


### PR DESCRIPTION
Use bundled gem directly

see
https://github.com/zzak/sdoc/pull/96
https://github.com/ruby/rdoc/pull/412