### PR TITLE
Adds "default_token_type" configuration parameter to optionally work around certain invalid implementations.

### DIFF
--- a/lib/openid_connect.rb
+++ b/lib/openid_connect.rb
@@ -76,6 +76,16 @@ module OpenIDConnect
     end
     @@http_config ||= block
   end
+
+  def self.default_token_type=(default_token_type)
+    @@default_token_type = default_token_type
+  end
+
+  def self.default_token_type
+    @@default_token_type
+  end
+
+  self.default_token_type = nil
 end
 
 require 'openid_connect/exception'

--- a/lib/openid_connect/client.rb
+++ b/lib/openid_connect/client.rb
@@ -27,14 +27,24 @@ module OpenIDConnect
 
     def handle_success_response(response)
       token_hash = JSON.parse(response.body).with_indifferent_access
-      case token_type = token_hash[:token_type].try(:downcase)
+      token_hash = token_hash.merge(client: self)
+      token_type = token_hash[:token_type].try(:downcase)
+
+      if token_type.nil?
+        token_type = OpenIDConnect.default_token_type.to_s.downcase
+      end
+
+      case token_type
       when 'bearer'
-        AccessToken.new token_hash.merge(client: self)
+        AccessToken.new token_hash
       else
-        raise Exception.new("Unexpected Token Type: #{token_type}")
+        raise Exception.new(
+          "Unexpected Token Type: #{token_type}. " \
+          'Use OpenIDConnect.default_token_type for non-conforming implementations'
+        )
       end
     rescue JSON::ParserError
-      raise Exception.new("Unknown Token Type")
+      raise Exception.new("Unknown Token Type.")
     end
   end
 end

--- a/lib/openid_connect/client.rb
+++ b/lib/openid_connect/client.rb
@@ -40,7 +40,7 @@ module OpenIDConnect
       else
         raise Exception.new(
           "Unexpected Token Type: #{token_type}. " \
-          'Use OpenIDConnect.default_token_type for non-conforming implementations'
+          'Use OpenIDConnect.default_token_type for non-conforming implementations.'
         )
       end
     rescue JSON::ParserError

--- a/spec/mock_response/access_token/missing_token_type.json
+++ b/spec/mock_response/access_token/missing_token_type.json
@@ -1,0 +1,5 @@
+{
+  "access_token":"access_token",
+  "refresh_token":"refresh_token",
+  "expires_in":3600
+}

--- a/spec/openid_connect/client_spec.rb
+++ b/spec/openid_connect/client_spec.rb
@@ -198,6 +198,22 @@ describe OpenIDConnect::Client do
       end
     end
 
+    context 'when token type is present' do
+      context 'default token type is set' do
+        after :each do
+          OpenIDConnect.default_token_type = nil
+        end
+
+        it 'should override default token type' do
+          OpenIDConnect.default_token_type = :lorem_ipsum
+
+          mock_json :post, client.token_endpoint, 'access_token/bearer', request_header: header_params, params: protocol_params do
+            access_token.should be_a OpenIDConnect::AccessToken
+          end
+        end
+      end
+    end
+
     context 'otherwise' do
       it 'should raise Unexpected Token Type exception' do
         mock_json :post, client.token_endpoint, 'access_token/mac', request_header: header_params, params: protocol_params do

--- a/spec/openid_connect/client_spec.rb
+++ b/spec/openid_connect/client_spec.rb
@@ -167,7 +167,33 @@ describe OpenIDConnect::Client do
         mock_json :post, client.token_endpoint, 'access_token/invalid_json', request_header: header_params, params: protocol_params do
           expect do
             access_token
-          end.to raise_error OpenIDConnect::Exception, 'Unknown Token Type'
+          end.to raise_error OpenIDConnect::Exception, /Unknown Token Type/
+        end
+      end
+    end
+
+    context 'when token type is missing' do
+      after :each do
+        OpenIDConnect.default_token_type = nil
+      end
+
+      context 'default token type bearer is set' do
+        it 'should return OpenIDConnect::AccessToken' do
+          OpenIDConnect.default_token_type = :bearer
+
+          mock_json :post, client.token_endpoint, 'access_token/missing_token_type', request_header: header_params, params: protocol_params do
+            access_token.should be_a OpenIDConnect::AccessToken
+          end
+        end
+      end
+
+      context 'default token type is missing' do
+        it 'should raise OpenIDConnect::Exception' do
+          mock_json :post, client.token_endpoint, 'access_token/missing_token_type', request_header: header_params, params: protocol_params do
+            expect do
+              access_token
+            end.to raise_error OpenIDConnect::Exception, /Unexpected Token Type/
+          end
         end
       end
     end
@@ -175,7 +201,7 @@ describe OpenIDConnect::Client do
     context 'otherwise' do
       it 'should raise Unexpected Token Type exception' do
         mock_json :post, client.token_endpoint, 'access_token/mac', request_header: header_params, params: protocol_params do
-          expect { access_token }.to raise_error OpenIDConnect::Exception, 'Unexpected Token Type: mac'
+          expect { access_token }.to raise_error OpenIDConnect::Exception, /Unexpected Token Type: mac/
         end
       end
     end


### PR DESCRIPTION
Although `RFC6749 4.2.2` correctly identifies that the `token_type` parameter is MANDATORY in the access token response, we've encountered some malformed implementations in the wild that omit this parameter.

To work around this, this branch introduces an OPTIONAL configuration option that allows one to make assumptions about the correct token_type (e.g. "Bearer") such that we can work around this issue in those cases.

Existing functionality and behaviour ONLY changes if this configuration option is set, and this default token type will only take effect if the authorization server responds with said malformed response.

Rspec tests are included, and if merged we'll add documentation to the github wiki so that users can utilise this functionality. 

