### PR TITLE
Adds "validate_discovery_issuer" configuration parameter to optionally work around certain invalid implementations.

### DIFF
--- a/lib/openid_connect.rb
+++ b/lib/openid_connect.rb
@@ -76,6 +76,16 @@ module OpenIDConnect
     end
     @@http_config ||= block
   end
+
+  def self.validate_discovery_issuer=(boolean)
+    @@validate_discovery_issuer = boolean
+  end
+
+  def self.validate_discovery_issuer
+    @@validate_discovery_issuer
+  end
+
+  self.validate_discovery_issuer = true
 end
 
 require 'openid_connect/exception'

--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -94,6 +94,8 @@ module OpenIDConnect
           private
 
           def validate_issuer_matching
+            return unless OpenIDConnect.validate_discovery_issuer
+
             if expected_issuer.present? && issuer != expected_issuer
               errors.add :issuer, 'mismatch'
             end

--- a/spec/openid_connect/discovery/provider/config_spec.rb
+++ b/spec/openid_connect/discovery/provider/config_spec.rb
@@ -56,13 +56,33 @@ describe OpenIDConnect::Discovery::Provider::Config do
       end
     end
 
-    context 'when response include invalid issuer' do
-      it do
-        expect do
-          mock_json :get, endpoint, 'discovery/config_with_invalid_issuer' do
-            OpenIDConnect::Discovery::Provider::Config.discover! provider
-          end
-        end.to raise_error OpenIDConnect::Discovery::DiscoveryFailed
+    describe 'when response include invalid issuer' do
+      context 'with normal configuration' do
+        it do
+          expect do
+            mock_json :get, endpoint, 'discovery/config_with_invalid_issuer' do
+              OpenIDConnect::Discovery::Provider::Config.discover! provider
+            end
+          end.to raise_error OpenIDConnect::Discovery::DiscoveryFailed
+        end
+      end
+
+      context 'when issuer validation is disabled.' do
+        before :each do
+          OpenIDConnect.validate_discovery_issuer = false
+        end
+
+        after :each do
+          OpenIDConnect.validate_discovery_issuer = true
+        end
+
+        it do
+          expect do
+            mock_json :get, endpoint, 'discovery/config_with_invalid_issuer' do
+              OpenIDConnect::Discovery::Provider::Config.discover! provider
+            end
+          end.not_to raise_error OpenIDConnect::Discovery::DiscoveryFailed
+        end
       end
     end
 


### PR DESCRIPTION
Although [OIDC Discovery 1.0 section 4.3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation) correctly identifies that the issuer must be validated to eliminate impersonation risks outlined in [Section 7.2](https://openid.net/specs/openid-connect-discovery-1_0.html#Impersonation), we have identified various non-conforming implementations in the wild with this parameter incorrectly.

To work around this, this branch introduces an OPTIONAL configuration option that allows one to bypass this requirement and skip this validation.

Existing functionality and behaviour ONLY changes if this configuration option is set, and by setting this configuration option it is assumed that implementing parties are aware of the potential risks outlined in [7.2](https://openid.net/specs/openid-connect-discovery-1_0.html#Impersonation) and have mitigated these problems elsewhere (or that the implementation is not production quality/public).

Rspec tests are included, and if merged we'll add documentation to the github wiki so that users can utilise this functionality. I'm keen personally to make sure that those toggling this option would do so being fully aware of the consequences, so I'm open to discussions on how to eg. omit warnings or ensure this is documented effectively to prevent anybody making mistakes here. 