### PR TITLE
Ruby Warnings

### DIFF
--- a/lib/openid_connect.rb
+++ b/lib/openid_connect.rb
@@ -73,7 +73,7 @@ module OpenIDConnect
   end
   def self.http_config(&block)
     @sub_protocols.each do |klass|
-      klass.http_config &block unless klass.http_config
+      klass.http_config(&block) unless klass.http_config
     end
     @@http_config ||= block
   end

--- a/lib/openid_connect/client/registrar.rb
+++ b/lib/openid_connect/client/registrar.rb
@@ -50,12 +50,12 @@ module OpenIDConnect
       ]
       attr_required :endpoint
       attr_optional :initial_access_token
-      attr_required *required_metadata_attributes
-      attr_optional *(metadata_attributes - required_metadata_attributes)
+      attr_required(*required_metadata_attributes)
+      attr_optional(*(metadata_attributes - required_metadata_attributes))
 
-      validates *required_attributes,   presence: true
+      validates(*required_attributes,   presence: true)
       validates :sector_identifier_uri, presence: {if: :sector_identifier_required?}
-      validates *singular_uri_attributes, url: true, allow_nil: true
+      validates(*singular_uri_attributes, url: true, allow_nil: true)
       validate :validate_plural_uri_attributes
       validate :validate_contacts
 

--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -25,12 +25,12 @@ module OpenIDConnect
               :op_tos_uri
             ]
           }
-          attr_required *(uri_attributes[:required] + [
+          attr_required(*(uri_attributes[:required] + [
             :response_types_supported,
             :subject_types_supported,
             :id_token_signing_alg_values_supported
-          ])
-          attr_optional *(uri_attributes[:optional] + [
+          ]))
+          attr_optional(*(uri_attributes[:optional] + [
             :scopes_supported,
             :response_modes_supported,
             :grant_types_supported,
@@ -54,10 +54,10 @@ module OpenIDConnect
             :request_parameter_supported,
             :request_uri_parameter_supported,
             :require_request_uri_registration
-          ])
+          ]))
 
-          validates *required_attributes, presence: true
-          validates *uri_attributes.values.flatten, url: true, allow_nil: true
+          validates(*required_attributes, presence: true)
+          validates(*uri_attributes.values.flatten, url: true, allow_nil: true)
           validates :issuer, with: :validate_issuer_matching
 
           def initialize(hash)

--- a/lib/openid_connect/request_object.rb
+++ b/lib/openid_connect/request_object.rb
@@ -5,10 +5,12 @@ module OpenIDConnect
     attr_optional :client_id, :response_type, :redirect_uri, :scope, :state, :nonce, :display, :prompt, :userinfo, :id_token
     validate :require_at_least_one_attributes
 
+    undef :id_token=
     def id_token=(attributes = {})
       @id_token = IdToken.new(attributes) if attributes.present?
     end
 
+    undef :userinfo=
     def userinfo=(attributes = {})
       @userinfo = UserInfo.new(attributes) if attributes.present?
     end

--- a/lib/openid_connect/response_object/user_info.rb
+++ b/lib/openid_connect/response_object/user_info.rb
@@ -47,6 +47,7 @@ module OpenIDConnect
         errors.add :address, address.errors.full_messages.join(', ') if address.present? && !address.valid?
       end
 
+      undef :address=
       def address=(hash_or_address)
         @address = case hash_or_address
         when Hash


### PR DESCRIPTION
This patch eliminates some Ruby warnings that we see when we require this gem with warnings option.
FYI here's how you can quickly reproduce the warnings.

`% ruby -wropenid_connect -ep`