### PR TITLE
Support for JWT userinfo response

### DIFF
--- a/lib/openid_connect/access_token.rb
+++ b/lib/openid_connect/access_token.rb
@@ -21,7 +21,11 @@ module OpenIDConnect
       res = yield
       case res.status
       when 200
-        JSON.parse(res.body).with_indifferent_access
+        json = if res.headers["Content-Type"] =~ /application\/jwt/
+          JWT.decode(res.body, nil, false).first.with_indifferent_access
+        else
+          JSON.parse(res.body).with_indifferent_access
+        end
       when 400
         raise BadRequest.new('API Access Faild', res)
       when 401


### PR DESCRIPTION
Currently we assume the userinfo response to always be JSON.

According to [the spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse), and required by my current use case, the response can also be a JWT token. This PR adds very basic support, without verifying the signature.