### PR TITLE
Use SHA256 instead of MD5, which allow code to be FIPS compliant

### DIFF
--- a/lib/openid_connect/discovery/provider/config/resource.rb
+++ b/lib/openid_connect/discovery/provider/config/resource.rb
@@ -1,3 +1,5 @@
+require "openssl"
+
 module OpenIDConnect
   module Discovery
     module Provider
@@ -27,8 +29,8 @@ module OpenIDConnect
           end
 
           def cache_key
-            md5 = Digest::MD5.hexdigest host
-            "swd:resource:opneid-conf:#{md5}"
+            sha256 = OpenSSL::Digest::SHA256.hexdigest host
+            "swd:resource:opneid-conf:#{sha256}"
           end
         end
       end

--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "swd", ">= 1.0.0"
   s.add_runtime_dependency "webfinger", ">= 1.0.1"
   s.add_runtime_dependency "rack-oauth2", ">= 1.6.1"
+  s.add_runtime_dependency "openssl", ">= 2.2.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-its"

--- a/spec/openid_connect/discovery/provider/config/resource_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/resource_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe OpenIDConnect::Discovery::Provider::Config::Resource do
   let(:resource) do
     uri = URI.parse 'http://server.example.com'
+#    SHA256 = 'e1335e881cf563c3fe4fb26a39fb410012e940a52cd9fa456fbe37b48d213ba2'
     OpenIDConnect::Discovery::Provider::Config::Resource.new uri
   end
 
@@ -16,5 +17,12 @@ describe OpenIDConnect::Discovery::Provider::Config::Resource do
         expect { resource.endpoint }.to raise_error SWD::Exception
       end
     end
+
+#   since the cache_key is private can't test it
+#    context 'when validate sha256 on host' do
+#      it do
+#        resource.cache_key.should == "swd:resource:opneid-conf:#{SHA256}"
+#      end
+#    end
   end
 end


### PR DESCRIPTION
close issue https://github.com/nov/openid_connect/issues/52