### PR TITLE
Add mtls capability for the user_info call.

### DIFF
--- a/spec/openid_connect/access_token_spec.rb
+++ b/spec/openid_connect/access_token_spec.rb
@@ -85,9 +85,16 @@ describe OpenIDConnect::AccessToken do
   end
 
   describe '#userinfo!' do
-    it do
+    it 'should call userinfo with standard client' do
       userinfo = mock_json :get, client.userinfo_uri, 'userinfo/openid', :HTTP_AUTHORIZATION => 'Bearer access_token' do
         access_token.userinfo!
+      end
+      userinfo.should be_instance_of OpenIDConnect::ResponseObject::UserInfo
+    end
+
+    it 'should call userinfo with headers if auth_type is :mtls' do
+      userinfo = mock_json :get, client.userinfo_uri, 'userinfo/openid', :HTTP_AUTHORIZATION => 'Bearer access_token' do
+        access_token.userinfo!(client_auth_method: :mtls)
       end
       userinfo.should be_instance_of OpenIDConnect::ResponseObject::UserInfo
     end


### PR DESCRIPTION
We had a client that required certs on the user_info call, while it seems excessive I can see this as an optional feature that can be used.

We ended up monkey patching to make work, but it would be nice to have the ability to mtls the userinfo! call.  This change is tested, safe, and does not affect the existing functionality.

Thanks!