### PR TITLE
skip response validation

### DIFF
--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -68,7 +68,8 @@ module OpenIDConnect
           end
 
           def as_json(options = {})
-            validate!
+            options ||= {} # options can be nil when to_json is called without options
+            validate! unless options[:skip_validation]
             (required_attributes + optional_attributes).inject({}) do |hash, _attr_|
               value = self.send _attr_
               hash.merge! _attr_ => value unless value.nil?


### PR DESCRIPTION
`validate!` for provider response will throw `"OpenIDConnect::ValidationFailed: Issuer is not a valid URL"` exception when using microsoft common tenant/endpoint for oauth.

See - https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant#update-your-code-to-send-requests-to-common
_Because the /common endpoint doesn’t correspond to a tenant and isn’t an issuer, when you examine the issuer value in the metadata for /common it has a templated URL instead of an actual value:_
`https://sts.windows.net/{tenantid}/`

As you can see above, the issuer is not a valid url due to `{tenantid}` and the issuer validation fails.

This PR adds an option to skip validation similar to the below:
See - https://github.com/nov/openid_connect/blob/4acd4802a79217c0124dde43f9233df678616a6b/lib/openid_connect/connect_object.rb#L29-L31


Signed-off-by: smcavallo <smcavallo@hotmail.com>