### PR TITLE
Include tzinfo-data gem

### DIFF
--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_runtime_dependency "tzinfo"
+  s.add_runtime_dependency "tzinfo-data"
   s.add_runtime_dependency "attr_required", ">= 1.0.0"
   s.add_runtime_dependency "activemodel"
   s.add_runtime_dependency "validate_url"

--- a/spec/openid_connect/client_spec.rb
+++ b/spec/openid_connect/client_spec.rb
@@ -33,6 +33,14 @@ describe OpenIDConnect::Client do
     end
   end
 
+  describe '#new' do
+    context 'when tzinfo-data is included' do
+      it 'does not raise an error' do
+        expect { client }.not_to raise_error TZInfo::DataSourceNotFound
+      end
+    end
+  end
+
   describe '#authorization_uri' do
     let(:scope) { nil }
     let(:prompt) { nil }


### PR DESCRIPTION
When you're using this gem outside the Rails environment (Sinatra, for instance), the gem `tzinfo-data` is not included, so when you do
```ruby
require 'openid_connect'
...
```
It will raise the `TZInfo::DataSourceNotFound` error.

The fix is pretty simple, as the doc suggests: https://github.com/tzinfo/tzinfo/wiki/Resolving-TZInfo::DataSourceNotFound-Errors

If you want to simulate this, I made a simple `Dockerfile` so you can try it.
```dockerfile
FROM ruby:3.1.2-alpine3.16

WORKDIR /opt

COPY Gemfile* ./
COPY VERSION .
COPY openid_connect.gemspec .

RUN apk add --update-cache --no-cache --virtual .build-deps g++ make \
    && apk add --update-cache --no-cache gcompat shared-mime-info git \
    && bundle install \
    && gem build openid_connect.gemspec \
    && gem install openid_connect-1.3.1.gem \
    && rm -rf /usr/local/bundle/cache/*.gem \
    && find /usr/local/bundle/gems/ -name "*.c" -delete \
    && find /usr/local/bundle/gems/ -name "*.o" -delete \
    && apk --purge del .build-deps

COPY . .
```
Build with
```
docker build . -t openid
```
And run IRB trying to import the `openid_connect` gem
```
docker run -it openid bundle exec irb

irb(main):001:0> require 'openid_connect'
```
Or run the tests, which will fail:
```
docker run -it openid bundle rake
```

If you run these steps with this commit, you'll see that everything works as supposed.