### PR TITLE
mTLS access token

### DIFF
--- a/lib/openid_connect/access_token.rb
+++ b/lib/openid_connect/access_token.rb
@@ -15,6 +15,13 @@ module OpenIDConnect
       ResponseObject::UserInfo.new hash
     end
 
+    def to_mtls(attributes = {})
+      (required_attributes + optional_attributes).each do |key|
+        attributes[key] = self.send(key)
+      end
+      MTLS.new attributes
+    end
+
     private
 
     def resource_request
@@ -34,3 +41,5 @@ module OpenIDConnect
     end
   end
 end
+
+require 'openid_connect/access_token/mtls'

--- a/lib/openid_connect/access_token/mtls.rb
+++ b/lib/openid_connect/access_token/mtls.rb
@@ -1,0 +1,9 @@
+module OpenIDConnect
+  class AccessToken::MTLS < AccessToken
+    def initialize(attributes = {})
+      super
+      http_client.ssl.client_key  = attributes[:private_key] || client.private_key
+      http_client.ssl.client_cert = attributes[:certificate] || client.certificate
+    end
+  end
+end


### PR DESCRIPTION
close #56

```ruby
c = OpenIDConnect::Client.new(
  identifier: 'id',
  secret: 'secret',
  userinfo_endpoint: 'https://example.com/userinfo',
  private_key: OpenSSL::PKey::RSA.generate(2048),
  certificate: OpenSSL::X509::Certificate.new
)

t = OpenIDConnect::AccessToken.new(access_token: 'token', client: c).to_mtls
t.userinfo!
```