### PR TITLE
Add revocation_endpoint to optional attrs found in Discovery

### DIFF
--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -16,6 +16,7 @@ module OpenIDConnect
             ],
             optional: [
               :token_endpoint,
+              :revocation_endpoint,
               :userinfo_endpoint,
               :registration_endpoint,
               :end_session_endpoint,

--- a/spec/openid_connect/discovery/provider/config/response_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/response_spec.rb
@@ -35,6 +35,17 @@ describe OpenIDConnect::Discovery::Provider::Config::Response do
     it { should_not be_valid }
   end
 
+  context 'when revocation_endpoint given' do
+    let(:revocation_endpoint) { 'https://server.example.com/revoke' }
+    let :attributes do
+      minimum_attributes.merge(
+        revocation_endpoint: revocation_endpoint
+      )
+    end
+    it { should be_valid }
+    its(:revocation_endpoint) { should == revocation_endpoint}
+  end
+
   context 'when end_session_endpoint given' do
     let(:end_session_endpoint) { 'https://server.example.com/end_session' }
     let :attributes do


### PR DESCRIPTION
Described in [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414).

I'm trying to using the [`revoke!` method in `rack-oauth2`](https://github.com/nov/rack-oauth2/blob/dd7830a7703e68f30dd6b1c4fa4f3ceb48cb11dd/lib/rack/oauth2/client.rb#L87) to invalidate an OIDC refresh token, but I first need to configure the client with a `revocation_endpoint` target. It would be convenient if this endpoint was included in the `Discovery::Provider::Config::Response` object.

I've added `revocation_endpoint` to the list of optional attributes on the `Response` class, and added a test case to that end.