### PR TITLE
Handle trailing slashes in the openid connect discovery endpoints gracefully

### DIFF
--- a/lib/openid_connect/discovery/provider/config.rb
+++ b/lib/openid_connect/discovery/provider/config.rb
@@ -5,7 +5,7 @@ module OpenIDConnect
         def self.discover!(identifier, cache_options = {})
           uri = URI.parse(identifier)
           Resource.new(uri).discover!(cache_options).tap do |response|
-            response.expected_issuer = identifier
+            response.expected_issuer = identifier.chomp("/")
             response.validate!
           end
         rescue SWD::Exception, ValidationFailed => e

--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -97,7 +97,7 @@ module OpenIDConnect
           private
 
           def validate_issuer_matching
-            if expected_issuer.present? && issuer != expected_issuer
+            if expected_issuer.present? && issuer&.chomp("/") != expected_issuer
               if OpenIDConnect.validate_discovery_issuer
                 errors.add :issuer, 'mismatch'
               else

--- a/spec/mock_response/discovery/config_with_trailing_slash.json
+++ b/spec/mock_response/discovery/config_with_trailing_slash.json
@@ -1,0 +1,13 @@
+{
+    "issuer": "https://connect.openid4.us/abop/",
+    "authorization_endpoint": "https://connect.openid4.us/abop/authorizations/new",
+    "token_endpoint": "https://connect.openid4.us/abop/access_tokens",
+    "userinfo_endpoint": "https://connect.openid4.us/abop/userinfo",
+    "registration_endpoint": "https://connect.openid4.us/abop/connect/client",
+    "scopes_supported": ["openid", "profile", "email", "address"],
+    "response_types_supported": ["code", "token", "id_token", "code token", "code id_token", "id_token token"],
+    "subject_types_supported": ["public", "pairwise"],
+    "claims_supported": ["sub", "iss", "name", "email"],
+    "jwks_uri": "https://connect-op.heroku.com/jwks.json",
+    "id_token_signing_alg_values_supported": ["RS256"]
+}

--- a/spec/openid_connect/discovery/provider/config_spec.rb
+++ b/spec/openid_connect/discovery/provider/config_spec.rb
@@ -46,6 +46,17 @@ describe OpenIDConnect::Discovery::Provider::Config do
       end
     end
 
+    context 'when OP identifier contains a trailing slash' do
+      let(:provider) { 'https://connect.openid4.us/abop' }
+      let(:endpoint) { 'https://connect.openid4.us/abop/.well-known/openid-configuration' }
+
+      it 'should construct well-known URI with given port' do
+        mock_json :get, endpoint, 'discovery/config_with_trailing_slash' do
+          OpenIDConnect::Discovery::Provider::Config.discover! provider
+        end
+      end
+    end
+
     context 'when SWD::Exception raised' do
       it do
         expect do


### PR DESCRIPTION
It's happening in my projects very often: a customer wants OIDC support, they provide a host as a variable to be used as the `OpenIDConnect::Discovery::Provider::Config.discover!` argument, that variable does not have a trailing slash, their discovery endpoint returns an identifier that does have a trailing slash. This PR aids the problem. While using `chomp` is naive, it also seems safer than regex, since it doesn't appear to cause unexpected regex bugs - but feel free to let me know your thoughts about it.

Seems like ruby isn't the only language that has stumbled upon this problem: https://github.com/coreos/go-oidc/issues/66

If you need an example, just set up a simple OIDC service in auth0 -- they add the trailing slash for everyone.