### PR TITLE
ability to override scopes

### DIFF
--- a/lib/openid_connect/client.rb
+++ b/lib/openid_connect/client.rb
@@ -8,9 +8,9 @@ module OpenIDConnect
     end
 
     def authorization_uri(params = {})
-      params[:scope] = setup_required_scope params[:scope]
+      params[:scope] = setup_required_scope(params[:scope], params[:override_scope])
       params[:prompt] = Array(params[:prompt]).join(' ')
-      super
+      super(params)
     end
 
     def userinfo_uri
@@ -19,9 +19,9 @@ module OpenIDConnect
 
     private
 
-    def setup_required_scope(scopes)
+    def setup_required_scope(scopes, override = false)
       _scopes_ = Array(scopes).join(' ').split(' ')
-      _scopes_ << 'openid' unless _scopes_.include?('openid')
+      _scopes_ << 'openid' unless _scopes_.include?('openid') || override
       _scopes_
     end
 

--- a/spec/openid_connect/client_spec.rb
+++ b/spec/openid_connect/client_spec.rb
@@ -37,11 +37,13 @@ describe OpenIDConnect::Client do
     let(:scope) { nil }
     let(:prompt) { nil }
     let(:response_type) { nil }
+    let(:override_scope) { nil }
     let(:query) do
       params = {
         scope: scope,
         prompt: prompt,
-        response_type: response_type
+        response_type: response_type,
+        override_scope: override_scope
       }.reject do |k,v|
         v.blank?
       end
@@ -97,6 +99,12 @@ describe OpenIDConnect::Client do
 
       context 'as default' do
         it { should == 'openid' }
+      end
+
+      context 'when override_scope is true' do
+        let(:scope) { :email }
+        let(:override_scope) { true }
+        it { should == 'email' }
       end
     end
 


### PR DESCRIPTION
in some clients, we have the requirement to send only `basic` scope, so added a param to override adding `open_id` always, also updated specs.