### PR TITLE
Don't use obsoleted `URI.regexp`

### DIFF
--- a/lib/openid_connect/client/registrar.rb
+++ b/lib/openid_connect/client/registrar.rb
@@ -118,7 +118,7 @@ module OpenIDConnect
 
       def valid_uri?(uri, schemes = ['http', 'https'])
         # NOTE: specify nil for schemes to allow any schemes
-        URI::regexp(schemes).match(uri).present?
+        URI::DEFAULT_PARSER.make_regexp(schemes).match(uri).present?
       end
 
       def validate_contacts


### PR DESCRIPTION
`URI.regexp` is obsoleted since Ruby 2.2.

```
$ ruby -w -r "uri" -e "URI::regexp"
-e:1: warning: URI.regexp is obsolete
```