### PR TITLE
Add optional skip_issuer parameter to IdToken.verify!

### DIFF
--- a/lib/openid_connect/response_object/id_token.rb
+++ b/lib/openid_connect/response_object/id_token.rb
@@ -21,9 +21,9 @@ module OpenIDConnect
         self.auth_time = auth_time.to_i unless auth_time.nil?
       end
 
-      def verify!(expected = {})
+      def verify!(expected = {}, skip_issuer = false)
         raise ExpiredToken.new('Invalid ID token: Expired token') unless exp.to_i > Time.now.to_i
-        raise InvalidIssuer.new('Invalid ID token: Issuer does not match') unless iss == expected[:issuer]
+        raise InvalidIssuer.new('Invalid ID token: Issuer does not match') unless (iss == expected[:issuer] || skip_issuer == true)
         raise InvalidNonce.new('Invalid ID Token: Nonce does not match') unless nonce == expected[:nonce]
 
         # aud(ience) can be a string or an array of strings

--- a/spec/openid_connect/response_object/id_token_spec.rb
+++ b/spec/openid_connect/response_object/id_token_spec.rb
@@ -79,6 +79,18 @@ describe OpenIDConnect::ResponseObject::IdToken do
       end
     end
 
+    context 'when issuer is invalid and skip_issuer is set' do
+      it do
+        id_token.verify!(
+          {
+            issuer: 'some-issuer',
+            client_id: attributes[:aud],
+          },
+          true
+        ).should == true
+      end
+    end
+
     context 'when issuer is missing' do
       it do
         expect do


### PR DESCRIPTION
This is especially useful when using Microsoft Entra ID common endpoint, as the issuer could be from another tenant.

When using this parameter it is recommended to set the audience as this stays the same even if the issuer is from another tenant.

Related https://github.com/omniauth/omniauth_openid_connect/issues/166

Closes #95