### PR TITLE
fix: typo in access_token

### DIFF
--- a/lib/openid_connect/access_token.rb
+++ b/lib/openid_connect/access_token.rb
@@ -30,7 +30,7 @@ module OpenIDConnect
       when 200
         res.body.with_indifferent_access
       when 400
-        raise BadRequest.new('API Access Faild', res)
+        raise BadRequest.new('API Access Failed', res)
       when 401
         raise Unauthorized.new('Access Token Invalid or Expired', res)
       when 403


### PR DESCRIPTION
Small typo in error message