### PR TITLE
Allow HTTP scheme in discovery URIs

### DIFF
--- a/lib/openid_connect/discovery/provider/config/resource.rb
+++ b/lib/openid_connect/discovery/provider/config/resource.rb
@@ -10,6 +10,7 @@ module OpenIDConnect
           class Expired < SWD::Resource::Expired; end
 
           def initialize(uri)
+            @scheme = uri.scheme
             @host = uri.host
             @port = uri.port unless [80, 443].include?(uri.port)
             @path = File.join uri.path, '.well-known/openid-configuration'
@@ -17,7 +18,12 @@ module OpenIDConnect
           end
 
           def endpoint
-            SWD.url_builder.build [nil, host, port, path, nil, nil]
+            URI::Generic.build(
+              scheme: @scheme,
+              host: host,
+              port: port,
+              path: path
+            ).to_s
           rescue URI::Error => e
             raise SWD::Exception.new(e.message)
           end

--- a/spec/openid_connect/discovery/provider/config/resource_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/resource_spec.rb
@@ -1,19 +1,41 @@
 require 'spec_helper'
 
 describe OpenIDConnect::Discovery::Provider::Config::Resource do
-  let(:resource) do
-    uri = URI.parse 'http://server.example.com'
-    OpenIDConnect::Discovery::Provider::Config::Resource.new uri
-  end
-
   describe '#endpoint' do
     context 'when invalid host' do
+      let(:resource) do
+        uri = URI.parse 'http://server.example.com'
+        OpenIDConnect::Discovery::Provider::Config::Resource.new uri
+      end
+      
       before do
         resource.host = 'hoge*hoge'
       end
 
       it do
         expect { resource.endpoint }.to raise_error SWD::Exception
+      end
+    end
+
+    context 'when HTTP URI' do
+      let(:resource) do
+        uri = URI.parse 'http://server.example.com'
+        OpenIDConnect::Discovery::Provider::Config::Resource.new uri
+      end
+
+      it 'should preserve HTTP scheme' do
+        expect(resource.endpoint.to_s).to eq 'http://server.example.com/.well-known/openid-configuration'
+      end
+    end
+
+    context 'when HTTPS URI' do
+      let(:resource) do
+        uri = URI.parse 'https://server.example.com'
+        OpenIDConnect::Discovery::Provider::Config::Resource.new uri
+      end
+
+      it 'should preserve HTTPS scheme' do
+        expect(resource.endpoint.to_s).to eq 'https://server.example.com/.well-known/openid-configuration'
       end
     end
   end


### PR DESCRIPTION
Previously, the discovery endpoint always used HTTPS due to relying on `SWD.url_builder`, which in turn used `URI::HTTPS` to build the URI, supporting only the HTTPS scheme. This change enables HTTP URLs to work correctly by using `URI::Generic.build` instead, preserving the original scheme.

- Store the original scheme from the input URI.
- Use `URI::Generic.build` instead of `SWD.url_builder/URI::HTTPS`.
- Add tests for both HTTP and HTTPS schemes. 
