### PR TITLE
Support Ruby 3.4

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'ubuntu-24.04']
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "swd", "~> 2.0"
   s.add_runtime_dependency "webfinger", "~> 2.0"
   s.add_runtime_dependency "rack-oauth2", "~> 2.2"
+  s.add_runtime_dependency "logger"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-its"


### PR DESCRIPTION
This PR adds Ruby 3.4 to the test matrix to ensure to work the gem with it.

Also, this PR adds `logger` to `add_runtime_dependency `. The `logger` gem will be a bundled gem from Ruby 3.5.
https://bugs.ruby-lang.org/issues/20309

So if we use `logger` as the standard library, Bundler shows the following warning.

```
src/github.com/nov/openid_connect/lib/openid_connect.rb:2: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0
```

This PR adds the `logger` to explicit dependency to fix the warning.