### PR TITLE
access_token: allow handling the /userinfo as a JWT token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- allow handling of /userinfo when returned as a JWT token.
+
 ## [2.2.0] - 2022-10-11
 
 ### Changed

--- a/lib/openid_connect/access_token.rb
+++ b/lib/openid_connect/access_token.rb
@@ -28,7 +28,11 @@ module OpenIDConnect
       res = yield
       case res.status
       when 200
-        res.body.with_indifferent_access
+        if response_is_jwt?(res)
+          JSON::JWT.decode(res.body, :skip_verification)
+        else
+          res.body
+        end
       when 400
         raise BadRequest.new('API Access Failed', res)
       when 401
@@ -38,6 +42,10 @@ module OpenIDConnect
       else
         raise HttpError.new(res.status, 'Unknown HttpError', res)
       end
+    end
+
+    def response_is_jwt?(response)
+      response.headers['content-type'].start_with? 'application/jwt'
     end
   end
 end

--- a/spec/openid_connect/access_token_spec.rb
+++ b/spec/openid_connect/access_token_spec.rb
@@ -97,5 +97,20 @@ describe OpenIDConnect::AccessToken do
       let(:request) { access_token.userinfo! }
       it_behaves_like :access_token_error_handling
     end
+
+    describe 'when the answer is a JWT' do
+      before do
+        allow(JSON::JWT).to receive(:decode).and_return({ foo: 'bar' })
+
+        stub_request(:get, client.userinfo_uri)
+          .to_return(body: "some token", headers: { "Content-Type" => "application/jwt" })
+      end
+
+      it 'decodes it seamlessly' do
+        userinfo = access_token.userinfo!
+
+        expect(userinfo.raw_attributes).to eq({ foo: 'bar' })
+      end
+    end
   end
 end


### PR DESCRIPTION
Though user information is usually returned as plain JSON, the spec does allow a JWT as well[1]:

> The UserInfo Claims MUST be returned as the members of a JSON object
unless a signed or encrypted response was requested during Client Registration.

I'm working with a provider that only returns JWT and does not allow Content-Type override. The workaround is to check the response's content type and parse the JWT if relevant.

[1]: https://openid.net/specs/openid-connect-core-1_0.html#UserInfo