### PR TITLE
Add POST support and custom headers to userinfo!

### DIFF
--- a/lib/openid_connect/access_token.rb
+++ b/lib/openid_connect/access_token.rb
@@ -8,9 +8,17 @@ module OpenIDConnect
       @token_type = :bearer
     end
 
-    def userinfo!(params = {})
+    def userinfo!(params = {}, http_method: :get, headers: {})
+      raise ArgumentError, 'http_method must be :get or :post' unless [:get, :post].include?(http_method)
+
       hash = resource_request do
-        get client.userinfo_uri, params
+        case http_method
+        when :get
+          get client.userinfo_uri, params, headers
+        when :post
+          # Per OIDC Core §5.3.1
+          post client.userinfo_uri, params, { 'Content-Type' => 'application/x-www-form-urlencoded' }.merge(headers)
+        end
       end
       ResponseObject::UserInfo.new hash
     end

--- a/spec/openid_connect/access_token_spec.rb
+++ b/spec/openid_connect/access_token_spec.rb
@@ -92,6 +92,28 @@ describe OpenIDConnect::AccessToken do
       userinfo.should be_instance_of OpenIDConnect::ResponseObject::UserInfo
     end
 
+    context 'when http_method is :post' do
+      it 'should make a POST request and return UserInfo' do
+        userinfo = mock_json :post, client.userinfo_uri, 'userinfo/openid', params: {}, request_header: { 'Content-Type' => 'application/x-www-form-urlencoded' } do
+          access_token.userinfo!(http_method: :post)
+        end
+        userinfo.should be_instance_of OpenIDConnect::ResponseObject::UserInfo
+      end
+
+      it 'should allow overriding Content-Type via headers' do
+        userinfo = mock_json :post, client.userinfo_uri, 'userinfo/openid', params: {}, request_header: { 'Content-Type' => 'application/json' } do
+          access_token.userinfo!(http_method: :post, headers: { 'Content-Type' => 'application/json' })
+        end
+        userinfo.should be_instance_of OpenIDConnect::ResponseObject::UserInfo
+      end
+    end
+
+    context 'when http_method is invalid' do
+      it 'should raise ArgumentError' do
+        expect { access_token.userinfo!(http_method: :delete) }.to raise_error ArgumentError, 'http_method must be :get or :post'
+      end
+    end
+
     describe 'error handling' do
       let(:endpoint) { client.userinfo_uri }
       let(:request) { access_token.userinfo! }


### PR DESCRIPTION
[OIDC Core §5.3.1](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoRequest) permits both GET and POST for the UserInfo endpoint. This adds `http_method` and `headers` keyword arguments to `AccessToken#userinfo!` so callers can use POST without monkeypatching.

- Default behavior (GET) is unchanged
- POST sets `Content-Type: application/x-www-form-urlencoded` by default per spec, overridable via `headers`
- Invalid `http_method` values raise `ArgumentError`
- Includes tests for POST, custom headers, and invalid method