### PR TITLE
Add `discovery_path` option to customize discovery document path

### DIFF
--- a/lib/openid_connect/discovery/provider/config.rb
+++ b/lib/openid_connect/discovery/provider/config.rb
@@ -2,9 +2,9 @@ module OpenIDConnect
   module Discovery
     module Provider
       class Config
-        def self.discover!(identifier, cache_options = {})
+        def self.discover!(identifier, cache_options = {}, discovery_path: '.well-known/openid-configuration')
           uri = URI.parse(identifier)
-          Resource.new(uri).discover!(cache_options).tap do |response|
+          Resource.new(uri, discovery_path: discovery_path).discover!(cache_options).tap do |response|
             response.expected_issuer = identifier
             response.validate!
           end

--- a/lib/openid_connect/discovery/provider/config/resource.rb
+++ b/lib/openid_connect/discovery/provider/config/resource.rb
@@ -9,10 +9,10 @@ module OpenIDConnect
 
           class Expired < SWD::Resource::Expired; end
 
-          def initialize(uri)
+          def initialize(uri, discovery_path: '.well-known/openid-configuration')
             @host = uri.host
             @port = uri.port unless [80, 443].include?(uri.port)
-            @path = File.join uri.path, '.well-known/openid-configuration'
+            @path = File.join uri.path, discovery_path
             attr_missing!
           end
 

--- a/spec/openid_connect/discovery/provider/config/resource_spec.rb
+++ b/spec/openid_connect/discovery/provider/config/resource_spec.rb
@@ -17,4 +17,30 @@ describe OpenIDConnect::Discovery::Provider::Config::Resource do
       end
     end
   end
+
+  describe 'discovery_path' do
+    context 'with default discovery_path' do
+      it 'should use .well-known/openid-configuration' do
+        uri = URI.parse 'https://example.com'
+        resource = OpenIDConnect::Discovery::Provider::Config::Resource.new uri
+        resource.endpoint.to_s.should == 'https://example.com/.well-known/openid-configuration'
+      end
+    end
+
+    context 'with custom discovery_path' do
+      it 'should use the provided path' do
+        uri = URI.parse 'https://example.com'
+        resource = OpenIDConnect::Discovery::Provider::Config::Resource.new uri, discovery_path: '.well-known/wallet-openid-configuration'
+        resource.endpoint.to_s.should == 'https://example.com/.well-known/wallet-openid-configuration'
+      end
+    end
+
+    context 'with custom discovery_path and URI path' do
+      it 'should join URI path and discovery_path' do
+        uri = URI.parse 'https://example.com/auth/realms/my-realm'
+        resource = OpenIDConnect::Discovery::Provider::Config::Resource.new uri, discovery_path: '.well-known/wallet-openid-configuration'
+        resource.endpoint.to_s.should == 'https://example.com/auth/realms/my-realm/.well-known/wallet-openid-configuration'
+      end
+    end
+  end
 end

--- a/spec/openid_connect/discovery/provider/config_spec.rb
+++ b/spec/openid_connect/discovery/provider/config_spec.rb
@@ -95,5 +95,21 @@ describe OpenIDConnect::Discovery::Provider::Config do
         end.to raise_error OpenIDConnect::Discovery::DiscoveryFailed
       end
     end
+
+    context 'when custom discovery_path is specified' do
+      let(:endpoint) { 'https://connect-op.heroku.com/.well-known/wallet-openid-configuration' }
+
+      it 'should fetch from the custom discovery path' do
+        mock_json :get, endpoint, 'discovery/config' do
+          config = OpenIDConnect::Discovery::Provider::Config.discover!(
+            provider,
+            {},
+            discovery_path: '.well-known/wallet-openid-configuration'
+          )
+          config.should be_instance_of OpenIDConnect::Discovery::Provider::Config::Response
+          config.authorization_endpoint.should == 'https://connect-op.heroku.com/authorizations/new'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Some providers run Keycloak (or similar) behind a custom login frontend. The standard `.well-known/openid-configuration` generated by Keycloak advertises its own `/auth` as `authorization_endpoint`, but users actually authenticate through the custom frontend (smartcard login, hardware MFA, etc.). The Keycloak endpoint itself doesn't render a usable login page.

These providers publish a second discovery document at a different path that overrides `authorization_endpoint` to point to the real login UI, while keeping everything else (token, userinfo, jwks, issuer) identical. We've hit this with [Pro Sante Connect](https://esante.gouv.fr/ens/offre/pro-sante-connect/documentation-technique) (French national health ID, uses `.well-known/wallet-openid-configuration`), and Intuit had the same problem (#45).

Right now `Resource#initialize` hardcodes `.well-known/openid-configuration`, so the only workaround is to disable discovery and hardcode all endpoints.

## Change

Single keyword argument `discovery_path:` defaulting to `'.well-known/openid-configuration'` on `Resource#initialize` and `Config.discover!`. Zero behavior change for existing consumers.

This is the foundation for the companion PR [omniauth/omniauth_openid_connect#214](https://github.com/omniauth/omniauth_openid_connect/pull/214) that exposes `discovery_path` as a strategy option.

Related: #45, #60, omniauth/omniauth_openid_connect#120