### PR TITLE
Reduce runtime dependencies

### DIFF
--- a/lib/openid_connect.rb
+++ b/lib/openid_connect.rb
@@ -1,11 +1,11 @@
 require 'json'
 require 'logger'
+require 'uri'
 require 'faraday'
 require 'swd'
 require 'webfinger'
 require 'active_model'
 require 'tzinfo'
-require 'validate_url'
 require 'attr_required'
 require 'attr_optional'
 require 'json/jwt'
@@ -20,6 +20,7 @@ module OpenIDConnect
   ).chomp
 
   EMAIL_REGEXP = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+  HTTP_URI_REGEXP = /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
 
   def self.logger
     @@logger

--- a/lib/openid_connect.rb
+++ b/lib/openid_connect.rb
@@ -6,7 +6,6 @@ require 'webfinger'
 require 'active_model'
 require 'tzinfo'
 require 'validate_url'
-require 'mail'
 require 'attr_required'
 require 'attr_optional'
 require 'json/jwt'
@@ -19,6 +18,8 @@ module OpenIDConnect
   VERSION = ::File.read(
     ::File.join(::File.dirname(__FILE__), '../VERSION')
   ).chomp
+
+  EMAIL_REGEXP = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
 
   def self.logger
     @@logger

--- a/lib/openid_connect.rb
+++ b/lib/openid_connect.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'logger'
 require 'faraday'
-require 'faraday/follow_redirects'
 require 'swd'
 require 'webfinger'
 require 'active_model'

--- a/lib/openid_connect/client/registrar.rb
+++ b/lib/openid_connect/client/registrar.rb
@@ -124,12 +124,7 @@ module OpenIDConnect
       def validate_contacts
         if contacts
           include_invalid = contacts.any? do |contact|
-            begin
-              mail = Mail::Address.new(contact)
-              mail.address != contact || mail.domain.split(".").length <= 1
-            rescue
-              :invalid
-            end
+            OpenIDConnect::EMAIL_REGEXP !~ contact
           end
           errors.add :contacts, 'includes invalid email' if include_invalid
         end

--- a/lib/openid_connect/client/registrar.rb
+++ b/lib/openid_connect/client/registrar.rb
@@ -55,7 +55,7 @@ module OpenIDConnect
 
       validates(*required_attributes,   presence: true)
       validates :sector_identifier_uri, presence: {if: :sector_identifier_required?}
-      validates(*singular_uri_attributes, url: true, allow_nil: true)
+      validates(*singular_uri_attributes, format: { with: OpenIDConnect::HTTP_URI_REGEXP }, allow_nil: true)
       validate :validate_plural_uri_attributes
       validate :validate_contacts
 

--- a/lib/openid_connect/discovery/provider/config/response.rb
+++ b/lib/openid_connect/discovery/provider/config/response.rb
@@ -57,7 +57,7 @@ module OpenIDConnect
           ]))
 
           validates(*required_attributes, presence: true)
-          validates(*uri_attributes.values.flatten, url: true, allow_nil: true)
+          validates(*uri_attributes.values.flatten, format: { with: OpenIDConnect::HTTP_URI_REGEXP }, allow_nil: true)
           validates :issuer, with: :validate_issuer_matching
 
           def initialize(hash)

--- a/lib/openid_connect/response_object/user_info.rb
+++ b/lib/openid_connect/response_object/user_info.rb
@@ -29,7 +29,7 @@ module OpenIDConnect
       validates :email_verified, :phone_number_verified, allow_nil: true, inclusion: {in: [true, false]}
       validates :zoneinfo,                               allow_nil: true, inclusion: {in: TZInfo::TimezoneProxy.all.collect(&:name)}
       validates :profile, :picture, :website,            allow_nil: true, url: true
-      validates :email,                                  allow_nil: true, format: { with: /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/ }
+      validates :email,                                  allow_nil: true, format: { with: OpenIDConnect::EMAIL_REGEXP }
       validates :updated_at,                             allow_nil: true, numericality: {only_integer: true}
       validate :validate_address
       validate :require_at_least_one_attributes

--- a/lib/openid_connect/response_object/user_info.rb
+++ b/lib/openid_connect/response_object/user_info.rb
@@ -28,7 +28,7 @@ module OpenIDConnect
 
       validates :email_verified, :phone_number_verified, allow_nil: true, inclusion: {in: [true, false]}
       validates :zoneinfo,                               allow_nil: true, inclusion: {in: TZInfo::TimezoneProxy.all.collect(&:name)}
-      validates :profile, :picture, :website,            allow_nil: true, url: true
+      validates :profile, :picture, :website,            allow_nil: true, format: { with: OpenIDConnect::HTTP_URI_REGEXP }
       validates :email,                                  allow_nil: true, format: { with: OpenIDConnect::EMAIL_REGEXP }
       validates :updated_at,                             allow_nil: true, numericality: {only_integer: true}
       validate :validate_address

--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "attr_required", ">= 1.0.0"
   s.add_runtime_dependency "activemodel"
   s.add_runtime_dependency "validate_url"
-  s.add_runtime_dependency "mail"
   s.add_runtime_dependency 'faraday', '~> 2.0'
   s.add_runtime_dependency "json-jwt", ">= 1.16"
   s.add_runtime_dependency "swd", "~> 2.0"

--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "tzinfo"
   s.add_runtime_dependency "attr_required", ">= 1.0.0"
   s.add_runtime_dependency "activemodel"
-  s.add_runtime_dependency "validate_url"
   s.add_runtime_dependency 'faraday', '~> 2.0'
   s.add_runtime_dependency "json-jwt", ">= 1.16"
   s.add_runtime_dependency "swd", "~> 2.0"

--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "webmock"
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "rexml"
 end

--- a/openid_connect.gemspec
+++ b/openid_connect.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "validate_url"
   s.add_runtime_dependency "mail"
   s.add_runtime_dependency 'faraday', '~> 2.0'
-  s.add_runtime_dependency 'faraday-follow_redirects'
   s.add_runtime_dependency "json-jwt", ">= 1.16"
   s.add_runtime_dependency "swd", "~> 2.0"
   s.add_runtime_dependency "webfinger", "~> 2.0"


### PR DESCRIPTION
## Summary

Removes three runtime dependencies and one dev dependency that were either unused or trivially replaceable with stdlib / existing code. Each removal is its own commit so they can be reviewed (and reverted) independently.

| Dependency | Type | Why it's removable |
|---|---|---|
| `faraday-follow_redirects` | runtime | `require`'d but the middleware was never registered in OpenIDConnect's Faraday stack. Dead weight. Still available transitively via swd/webfinger/rack-oauth2. |
| `rexml` | dev | Not referenced in lib or specs. Still available transitively via webmock → crack → rexml. |
| `mail` | runtime | Only used to validate client contact emails in the registrar. Replaced with the email regex already used for `UserInfo#email`. Drops a heavy tree (net-imap, net-smtp, net-pop, mini_mime, …). |
| `validate_url` | runtime | Only the default `url: true` validator was used. Replaced with a regexp built from `URI::DEFAULT_PARSER` — the same stdlib approach the registrar already uses for `redirect_uris`. Also drops `public_suffix` from the runtime closure. |

## Notes

- Two small shared constants are introduced in `lib/openid_connect.rb`: `EMAIL_REGEXP` and `HTTP_URI_REGEXP`. `EMAIL_REGEXP` also de-dupes the inline regex previously in `UserInfo`.
- **No globally-named validator is defined.** Reopening `ActiveModel::Validations::UrlValidator` would collide with `validate_url` (or any other gem) when both load in the same app, so the replacement uses `format:` with a module constant instead.

## Behavior

Validation behavior is preserved, with one edge case: a scheme-only URI like `http://` (no host) now passes URL validation. This makes singular URI attributes (e.g. `sector_identifier_uri`) consistent with how the gem already validates plural ones (`redirect_uris`).

Contact-email validation is unchanged: addresses without an `@` or with a dotless domain (e.g. `nov@localhost`) remain invalid.