### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/spec/helpers/crypto_spec_helper.rb
+++ b/spec/helpers/crypto_spec_helper.rb
@@ -8,7 +8,7 @@ module CryptoSpecHelper
   end
 
   def private_key
-    @private_key ||= OpenSSL::PKey::RSA.new rsa_key.export(OpenSSL::Cipher.new('DES-EDE3-CBC'), 'pass-phrase'), 'pass-phrase'
+    @private_key ||= OpenSSL::PKey::RSA.new rsa_key.export(OpenSSL::Cipher.new('AES-256-CBC'), 'pass-phrase'), 'pass-phrase'
   end
 
   def ec_key


### PR DESCRIPTION
Potential fix for [https://github.com/nov/openid_connect/security/code-scanning/1](https://github.com/nov/openid_connect/security/code-scanning/1)

Use a modern symmetric cipher for private key export encryption, e.g. AES-256-CBC, while keeping behavior the same (export encrypted private key and re-import with passphrase).

Best single fix in this file:
- In `spec/helpers/crypto_spec_helper.rb`, method `private_key`, replace:
  - `OpenSSL::Cipher.new('DES-EDE3-CBC')`
  - with `OpenSSL::Cipher.new('AES-256-CBC')`
- Keep the same passphrase and key export/import flow to avoid functional changes to tests.

No new methods or imports are required since `OpenSSL` is already being used in the shown code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
